### PR TITLE
MNT: Make repr and str reflect the python name

### DIFF
--- a/crates/inchworm-py/src/dimensions.rs
+++ b/crates/inchworm-py/src/dimensions.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::types::PyString;
 
 /// DimensionRegistry for managing dimensions.
 #[pyclass]
@@ -15,11 +16,13 @@ impl DimensionRegistry {
         }
     }
 
-    fn __repr__(&self) -> String {
-        "DimensionRegistry()".to_string()
+    fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
+        let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
+        Ok(format!("{}()", class_name))
     }
-    fn __str__(&self) -> String {
-        "DimensionRegistry".to_string()
+    fn __str__(slf: &Bound<'_, Self>) -> PyResult<String> {
+        let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
+        Ok(format!("{}", class_name))
     }
 }
 


### PR DESCRIPTION
## Description

This pull request makes the `__repr__` and `__str__` methods reflect the Python class name.

## Motivation and context

If the class is subclassed or modified, the hardcoded value might not reflect the real Python class name.

## What this does

If the class is subclassed or modified, the new methods access the bound type and the representation is automatically updated.

## Related issues

Closes #27. Related to #25.

## Checklist:

- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] I have linked relevant issues or PRs
