### PR TITLE
✨ Add basic DerivedDimensionDef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ name = "inchworm-dimensions"
 version = "0.1.0"
 dependencies = [
  "num-rational",
+ "thiserror",
 ]
 
 [[package]]
@@ -212,6 +213,26 @@ name = "target-lexicon"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,9 @@ dependencies = [
 [[package]]
 name = "inchworm-dimensions"
 version = "0.1.0"
+dependencies = [
+ "num-rational",
+]
 
 [[package]]
 name = "inchworm-py"
@@ -53,6 +56,45 @@ name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]

--- a/crates/inchworm-dimensions/Cargo.toml
+++ b/crates/inchworm-dimensions/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 num-rational = "0.4.2"
+thiserror = "2.0.18"
 
 [lints.clippy]
 indexing_slicing = "deny"

--- a/crates/inchworm-dimensions/Cargo.toml
+++ b/crates/inchworm-dimensions/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
+num-rational = "0.4.2"
 
 [lints.clippy]
 indexing_slicing = "deny"
@@ -15,4 +16,3 @@ fallible_impl_from = "deny"
 wildcard_enum_match_arm = "deny"
 unneeded_field_pattern = "deny"
 fn_params_excessive_bools = "deny"
-new_without_default = "allow"

--- a/crates/inchworm-dimensions/src/base_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/base_dimension_def.rs
@@ -75,6 +75,20 @@ mod tests {
         assert_eq!(dimension.symbol, "τ");
     }
 
+    // Test BaseDimensionDef creation with empty name
+    #[test]
+    fn test_base_dimension_def_empty_name() {
+        let result = BaseDimensionDef::new("", "L");
+        assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
+    }
+
+    // Test BaseDimensionDef creation with empty symbol
+    #[test]
+    fn test_base_dimension_def_empty_symbol() {
+        let result = BaseDimensionDef::new("Length", "");
+        assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
+    }
+
     // Test BaseDimensionDef name method
     #[test]
     fn test_base_dimension_get_name() {

--- a/crates/inchworm-dimensions/src/base_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/base_dimension_def.rs
@@ -89,14 +89,14 @@ mod tests {
         assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
     }
 
-    // Test BaseDimensionDef name method
+    // Test name() method
     #[test]
     fn test_base_dimension_get_name() {
         let dimension = BaseDimensionDef::new("Mass", "M").unwrap();
         assert_eq!(dimension.name(), "Mass");
     }
 
-    // Test BaseDimensionDef symbol method
+    // Test symbol() method
     #[test]
     fn test_base_dimension_get_symbol() {
         let dimension = BaseDimensionDef::new("Current", "I").unwrap();

--- a/crates/inchworm-dimensions/src/base_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/base_dimension_def.rs
@@ -1,0 +1,76 @@
+/// A definition of a base physical dimension.
+///
+/// `BaseDimensionDef` represents fundamental physical dimensions such as
+/// length, mass, and time, that form the basis for derived dimensions in a
+/// units system.
+///
+/// # Examples
+///
+/// ```
+/// use inchworm_dimensions::BaseDimensionDef;
+///
+/// let dimension = BaseDimensionDef::new("length", "L");
+/// ```
+#[derive(Debug, Clone)]
+pub struct BaseDimensionDef {
+    // The name of the base dimension (e.g., "length", "mass").
+    name: String,
+    // A symbol for the base dimension (e.g., "L" for length).
+    symbol: String,
+}
+
+impl BaseDimensionDef {
+    /// Creates a new `BaseDimensionDef` with the given name and symbol.
+    pub fn new(name: &str, symbol: &str) -> Self {
+        // TODO: Raise error if name or symbol are empty
+        Self {
+            name: name.to_string(),
+            symbol: symbol.to_string(),
+        }
+    }
+
+    /// Returns the name of the base dimension.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the symbol of the base dimension.
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test creation of BaseDimensionDef
+    #[test]
+    fn test_base_dimension_def_creation() {
+        let dimension = BaseDimensionDef::new("Length", "L");
+        assert_eq!(dimension.name, "Length");
+        assert_eq!(dimension.symbol, "L");
+    }
+
+    // Test creation of BaseDimensionDef with a non-ASCII symbol
+    #[test]
+    fn test_base_dimension_with_non_ascii_symbol() {
+        let dimension = BaseDimensionDef::new("Time", "τ");
+        assert_eq!(dimension.name, "Time");
+        assert_eq!(dimension.symbol, "τ");
+    }
+
+    // Test BaseDimensionDef name method
+    #[test]
+    fn test_base_dimension_get_name() {
+        let dimension = BaseDimensionDef::new("Mass", "M");
+        assert_eq!(dimension.name(), "Mass");
+    }
+
+    // Test BaseDimensionDef symbol method
+    #[test]
+    fn test_base_dimension_get_symbol() {
+        let dimension = BaseDimensionDef::new("Current", "I");
+        assert_eq!(dimension.symbol(), "I");
+    }
+}

--- a/crates/inchworm-dimensions/src/base_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/base_dimension_def.rs
@@ -1,3 +1,5 @@
+use crate::errors::DimensionError;
+
 /// A definition of a base physical dimension.
 ///
 /// `BaseDimensionDef` represents fundamental physical dimensions such as
@@ -21,12 +23,21 @@ pub struct BaseDimensionDef {
 
 impl BaseDimensionDef {
     /// Creates a new `BaseDimensionDef` with the given name and symbol.
-    pub fn new(name: &str, symbol: &str) -> Self {
-        // TODO: Raise error if name or symbol are empty
-        Self {
+    pub fn new(name: &str, symbol: &str) -> Result<Self, DimensionError> {
+        if name.is_empty() {
+            return Err(DimensionError::InvalidDefinition(
+                "Base dimension name cannot be empty.".to_string(),
+            ));
+        }
+        if symbol.is_empty() {
+            return Err(DimensionError::InvalidDefinition(
+                format!("Base dimension ({}) symbol cannot be empty.", name).to_string(),
+            ));
+        }
+        Ok(Self {
             name: name.to_string(),
             symbol: symbol.to_string(),
-        }
+        })
     }
 
     /// Returns the name of the base dimension.
@@ -47,7 +58,7 @@ mod tests {
     // Test creation of BaseDimensionDef
     #[test]
     fn test_base_dimension_def_creation() {
-        let dimension = BaseDimensionDef::new("Length", "L");
+        let dimension = BaseDimensionDef::new("Length", "L").unwrap();
         assert_eq!(dimension.name, "Length");
         assert_eq!(dimension.symbol, "L");
     }
@@ -55,7 +66,7 @@ mod tests {
     // Test creation of BaseDimensionDef with a non-ASCII symbol
     #[test]
     fn test_base_dimension_with_non_ascii_symbol() {
-        let dimension = BaseDimensionDef::new("Time", "τ");
+        let dimension = BaseDimensionDef::new("Time", "τ").unwrap();
         assert_eq!(dimension.name, "Time");
         assert_eq!(dimension.symbol, "τ");
     }
@@ -63,14 +74,14 @@ mod tests {
     // Test BaseDimensionDef name method
     #[test]
     fn test_base_dimension_get_name() {
-        let dimension = BaseDimensionDef::new("Mass", "M");
+        let dimension = BaseDimensionDef::new("Mass", "M").unwrap();
         assert_eq!(dimension.name(), "Mass");
     }
 
     // Test BaseDimensionDef symbol method
     #[test]
     fn test_base_dimension_get_symbol() {
-        let dimension = BaseDimensionDef::new("Current", "I");
+        let dimension = BaseDimensionDef::new("Current", "I").unwrap();
         assert_eq!(dimension.symbol(), "I");
     }
 }

--- a/crates/inchworm-dimensions/src/base_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/base_dimension_def.rs
@@ -11,18 +11,22 @@ use crate::errors::DimensionError;
 /// ```
 /// use inchworm_dimensions::BaseDimensionDef;
 ///
-/// let dimension = BaseDimensionDef::new("length", "L");
+/// let dimension = BaseDimensionDef::new("length", "L").unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct BaseDimensionDef {
-    // The name of the base dimension (e.g., "length", "mass").
+    /// The name of the base dimension (e.g., "length", "mass").
     name: String,
-    // A symbol for the base dimension (e.g., "L" for length).
+    /// A symbol for the base dimension (e.g., "L" for length).
     symbol: String,
 }
 
 impl BaseDimensionDef {
     /// Creates a new `BaseDimensionDef` with the given name and symbol.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DimensionError::InvalidDefinition`] if the name or symbol is empty.
     pub fn new(name: &str, symbol: &str) -> Result<Self, DimensionError> {
         if name.is_empty() {
             return Err(DimensionError::InvalidDefinition(

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -1,4 +1,4 @@
-use crate::dimension_component::DimensionComponent;
+use crate::{dimension_component::DimensionComponent, errors::DimensionError};
 
 /// A definition of a derived physical dimension.
 ///
@@ -35,13 +35,35 @@ pub struct DerivedDimensionDef {
 
 impl DerivedDimensionDef {
     /// Creates a new `DerivedDimensionDef` with the given name and symbol.
-    pub fn new(name: &str, symbol: &str, components: Vec<DimensionComponent>) -> Self {
-        // TODO: Raise error if name, symbol, or components are empty
-        Self {
+    pub fn new(
+        name: &str,
+        symbol: &str,
+        components: Vec<DimensionComponent>,
+    ) -> Result<Self, DimensionError> {
+        if name.is_empty() {
+            return Err(DimensionError::InvalidDefinition(
+                "Derived dimension name cannot be empty.".to_string(),
+            ));
+        }
+        if symbol.is_empty() {
+            return Err(DimensionError::InvalidDefinition(
+                format!("Derived dimension ({}) symbol cannot be empty.", name).to_string(),
+            ));
+        }
+        if components.is_empty() {
+            return Err(DimensionError::InvalidDefinition(
+                format!(
+                    "Derived dimension ({}) must have at least one component.",
+                    name
+                )
+                .to_string(),
+            ));
+        }
+        Ok(Self {
             name: name.to_string(),
             symbol: symbol.to_string(),
             components,
-        }
+        })
     }
 
     /// Returns the name of the derived dimension.
@@ -69,7 +91,7 @@ mod tests {
 
     // Helper function to create a base dimension wrapped in an Arc and converted to DimensionDef
     fn make_base_dimension(name: &str, symbol: &str) -> Arc<DimensionDef> {
-        Arc::new(BaseDimensionDef::new(name, symbol).into())
+        Arc::new(BaseDimensionDef::new(name, symbol).unwrap().into())
     }
 
     // Test creation of DerivedDimensionDef
@@ -113,7 +135,8 @@ mod tests {
                 DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
                 DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
             ],
-        );
+        )
+        .unwrap();
         assert_eq!(velocity.name(), "Velocity");
     }
 
@@ -129,7 +152,8 @@ mod tests {
                 DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
                 DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
             ],
-        );
+        )
+        .unwrap();
         assert_eq!(velocity.symbol(), "v");
     }
 }

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -1,0 +1,135 @@
+use crate::dimension_component::DimensionComponent;
+
+/// A definition of a derived physical dimension.
+///
+/// `DerivedDimensionDef` represents derived physical dimensions that are
+/// formed by combining base or other derived dimensions in a units system.
+///
+/// # Examples
+///
+/// ```
+/// use inchworm_dimensions::{BaseDimensionDef, DerivedDimensionDef, DimensionComponent};
+/// use num_rational::Ratio;
+/// use std::sync::Arc;
+///
+/// let length = Arc::new(BaseDimensionDef::new("Length", "L").into());
+/// let time = Arc::new(BaseDimensionDef::new("Time", "T").into());
+/// let _velocity = DerivedDimensionDef::new(
+///     "Velocity",
+///     "v",
+///     vec![
+///         DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
+///         DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+///     ],
+/// );
+/// ```
+#[derive(Debug, Clone)]
+pub struct DerivedDimensionDef {
+    // The name of the derived dimension (e.g., "velocity", "acceleration").
+    name: String,
+    // A symbol for the derived dimension (e.g., "V" for velocity).
+    symbol: String,
+    // Components whose product forms the derived dimension
+    components: Vec<DimensionComponent>,
+}
+
+impl DerivedDimensionDef {
+    /// Creates a new `DerivedDimensionDef` with the given name and symbol.
+    pub fn new(name: &str, symbol: &str, components: Vec<DimensionComponent>) -> Self {
+        // TODO: Raise error if name, symbol, or components are empty
+        Self {
+            name: name.to_string(),
+            symbol: symbol.to_string(),
+            components,
+        }
+    }
+
+    /// Returns the name of the derived dimension.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the symbol of the derived dimension.
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+
+    /// Returns the components of the derived dimension.
+    pub fn components(&self) -> &[DimensionComponent] {
+        &self.components
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DimensionDef, base_dimension_def::BaseDimensionDef};
+    use num_rational::Ratio;
+    use std::sync::Arc;
+
+    // Helper function to create a base dimension wrapped in an Arc and converted to DimensionDef
+    fn make_base_dimension(name: &str, symbol: &str) -> Arc<DimensionDef> {
+        Arc::new(BaseDimensionDef::new(name, symbol).into())
+    }
+
+    // Test creation of DerivedDimensionDef
+    #[test]
+    fn test_derived_dimension_def_creation() {
+        let length = make_base_dimension("Length", "L");
+        let time = make_base_dimension("Time", "T");
+        let _velocity = DerivedDimensionDef::new(
+            "Velocity",
+            "v",
+            vec![
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+            ],
+        );
+    }
+
+    // Test creation of DerivedDimensionDef with a non-ASCII symbol
+    #[test]
+    fn test_derived_dimension_with_non_ascii_symbol() {
+        let length = make_base_dimension("Length", "L");
+        let _strain = DerivedDimensionDef::new(
+            "Strain",
+            "ε",
+            vec![
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(-1)),
+            ],
+        );
+    }
+
+    // Test DerivedDimensionDef name method
+    #[test]
+    fn test_derived_dimension_get_name() {
+        let length = make_base_dimension("Length", "L");
+        let time = make_base_dimension("Time", "T");
+        let velocity = DerivedDimensionDef::new(
+            "Velocity",
+            "v",
+            vec![
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+            ],
+        );
+        assert_eq!(velocity.name(), "Velocity");
+    }
+
+    // Test DerivedDimensionDef symbol method
+    #[test]
+    fn test_derived_dimension_get_symbol() {
+        let length = make_base_dimension("Length", "L");
+        let time = make_base_dimension("Time", "T");
+        let velocity = DerivedDimensionDef::new(
+            "Velocity",
+            "v",
+            vec![
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+            ],
+        );
+        assert_eq!(velocity.symbol(), "v");
+    }
+}

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -200,4 +200,26 @@ mod tests {
         .unwrap();
         assert_eq!(velocity.symbol(), "v");
     }
+
+    // Test DerivedDimensionDef components method
+    #[test]
+    fn test_derived_dimension_get_components() {
+        let length = make_base_dimension("Length", "L");
+        let time = make_base_dimension("Time", "T");
+        let velocity = DerivedDimensionDef::new(
+            "Velocity",
+            "v",
+            vec![
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)).unwrap(),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap(),
+            ],
+        )
+        .unwrap();
+        let components = velocity.components();
+        assert_eq!(components.len(), 2);
+        assert_eq!(components[0].dimension_def().unwrap().name(), "Length");
+        assert_eq!(components[0].exponent(), Ratio::from(1));
+        assert_eq!(components[1].dimension_def().unwrap().name(), "Time");
+        assert_eq!(components[1].exponent(), Ratio::from(-1));
+    }
 }

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -167,7 +167,7 @@ mod tests {
         assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
     }
 
-    // Test DerivedDimensionDef name method
+    // Test name() method
     #[test]
     fn test_derived_dimension_get_name() {
         let length = make_base_dimension("Length", "L");
@@ -184,7 +184,7 @@ mod tests {
         assert_eq!(velocity.name(), "Velocity");
     }
 
-    // Test DerivedDimensionDef symbol method
+    // Test symbol() method
     #[test]
     fn test_derived_dimension_get_symbol() {
         let length = make_base_dimension("Length", "L");
@@ -201,7 +201,7 @@ mod tests {
         assert_eq!(velocity.symbol(), "v");
     }
 
-    // Test DerivedDimensionDef components method
+    // Test components() method
     #[test]
     fn test_derived_dimension_get_components() {
         let length = make_base_dimension("Length", "L");

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -50,27 +50,22 @@ impl DerivedDimensionDef {
             ));
         }
         if symbol.is_empty() {
-            return Err(DimensionError::InvalidDefinition(
-                format!("Derived dimension ({}) symbol cannot be empty.", name).to_string(),
-            ));
+            return Err(DimensionError::InvalidDefinition(format!(
+                "Derived dimension ({}) symbol cannot be empty.",
+                name
+            )));
         }
         if components.is_empty() {
-            return Err(DimensionError::InvalidDefinition(
-                format!(
-                    "Derived dimension ({}) must have at least one component.",
-                    name
-                )
-                .to_string(),
-            ));
+            return Err(DimensionError::InvalidDefinition(format!(
+                "Derived dimension ({}) must have at least one component.",
+                name
+            )));
         }
         if components.iter().any(|c| !c.is_valid()) {
-            return Err(DimensionError::InvalidDefinition(
-                format!(
-                    "Derived dimension ({}) has invalid components. All component dimension references must be valid.",
-                    name
-                )
-                .to_string(),
-            ));
+            return Err(DimensionError::InvalidDefinition(format!(
+                "Derived dimension ({}) has invalid components. All component dimension references must be valid.",
+                name
+            )));
         }
         Ok(Self {
             name: name.to_string(),
@@ -217,9 +212,9 @@ mod tests {
         .unwrap();
         let components = velocity.components();
         assert_eq!(components.len(), 2);
-        assert_eq!(components[0].dimension_def().unwrap().name(), "Length");
+        assert_eq!(components[0].dimension().unwrap().name(), "Length");
         assert_eq!(components[0].exponent(), Ratio::from(1));
-        assert_eq!(components[1].dimension_def().unwrap().name(), "Time");
+        assert_eq!(components[1].dimension().unwrap().name(), "Time");
         assert_eq!(components[1].exponent(), Ratio::from(-1));
     }
 }

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -12,8 +12,8 @@ use crate::{dimension_component::DimensionComponent, errors::DimensionError};
 /// use num_rational::Ratio;
 /// use std::sync::Arc;
 ///
-/// let length = Arc::new(BaseDimensionDef::new("Length", "L").into());
-/// let time = Arc::new(BaseDimensionDef::new("Time", "T").into());
+/// let length = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+/// let time = Arc::new(BaseDimensionDef::new("Time", "T").unwrap().into());
 /// let _velocity = DerivedDimensionDef::new(
 ///     "Velocity",
 ///     "v",
@@ -21,20 +21,24 @@ use crate::{dimension_component::DimensionComponent, errors::DimensionError};
 ///         DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
 ///         DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
 ///     ],
-/// );
+/// ).unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct DerivedDimensionDef {
-    // The name of the derived dimension (e.g., "velocity", "acceleration").
+    /// The name of the derived dimension (e.g., "velocity", "acceleration").
     name: String,
-    // A symbol for the derived dimension (e.g., "V" for velocity).
+    /// A symbol for the derived dimension (e.g., "V" for velocity).
     symbol: String,
-    // Components whose product forms the derived dimension
+    /// Components whose product forms the derived dimension
     components: Vec<DimensionComponent>,
 }
 
 impl DerivedDimensionDef {
     /// Creates a new `DerivedDimensionDef` with the given name and symbol.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DimensionError::InvalidDefinition`] if the name or symbol is empty, or if there are no components.
     pub fn new(
         name: &str,
         symbol: &str,

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -18,8 +18,8 @@ use crate::{dimension_component::DimensionComponent, errors::DimensionError};
 ///     "Velocity",
 ///     "v",
 ///     vec![
-///         DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
-///         DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+///         DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)).unwrap(),
+///         DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap(),
 ///     ],
 /// ).unwrap();
 /// ```
@@ -58,6 +58,15 @@ impl DerivedDimensionDef {
             return Err(DimensionError::InvalidDefinition(
                 format!(
                     "Derived dimension ({}) must have at least one component.",
+                    name
+                )
+                .to_string(),
+            ));
+        }
+        if components.iter().any(|c| !c.is_valid()) {
+            return Err(DimensionError::InvalidDefinition(
+                format!(
+                    "Derived dimension ({}) has invalid components. All component dimension references must be valid.",
                     name
                 )
                 .to_string(),
@@ -107,8 +116,8 @@ mod tests {
             "Velocity",
             "v",
             vec![
-                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
-                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)).unwrap(),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap(),
             ],
         );
     }
@@ -121,8 +130,8 @@ mod tests {
             "Strain",
             "ε",
             vec![
-                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
-                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(-1)),
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)).unwrap(),
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(-1)).unwrap(),
             ],
         );
     }
@@ -134,10 +143,7 @@ mod tests {
         let result = DerivedDimensionDef::new(
             "",
             "f",
-            vec![DimensionComponent::new(
-                Arc::downgrade(&time),
-                Ratio::from(-1),
-            )],
+            vec![DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap()],
         );
         assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
     }
@@ -149,10 +155,7 @@ mod tests {
         let result = DerivedDimensionDef::new(
             "Frequency",
             "",
-            vec![DimensionComponent::new(
-                Arc::downgrade(&time),
-                Ratio::from(-1),
-            )],
+            vec![DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap()],
         );
         assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
     }
@@ -173,8 +176,8 @@ mod tests {
             "Velocity",
             "v",
             vec![
-                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
-                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)).unwrap(),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap(),
             ],
         )
         .unwrap();
@@ -190,8 +193,8 @@ mod tests {
             "Velocity",
             "v",
             vec![
-                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)),
-                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)),
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)).unwrap(),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap(),
             ],
         )
         .unwrap();

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -127,6 +127,43 @@ mod tests {
         );
     }
 
+    // Test creation of DerivedDimensionDef with empty name
+    #[test]
+    fn test_derived_dimension_with_empty_name() {
+        let time = make_base_dimension("Time", "T");
+        let result = DerivedDimensionDef::new(
+            "",
+            "f",
+            vec![DimensionComponent::new(
+                Arc::downgrade(&time),
+                Ratio::from(-1),
+            )],
+        );
+        assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
+    }
+
+    // Test creation of DerivedDimensionDef with empty symbol
+    #[test]
+    fn test_derived_dimension_with_empty_symbol() {
+        let time = make_base_dimension("Time", "T");
+        let result = DerivedDimensionDef::new(
+            "Frequency",
+            "",
+            vec![DimensionComponent::new(
+                Arc::downgrade(&time),
+                Ratio::from(-1),
+            )],
+        );
+        assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
+    }
+
+    // Test creation of DerivedDimensionDef with no components
+    #[test]
+    fn test_derived_dimension_with_no_components() {
+        let result = DerivedDimensionDef::new("Dimensionless", "1", vec![]);
+        assert!(matches!(result, Err(DimensionError::InvalidDefinition(_))));
+    }
+
     // Test DerivedDimensionDef name method
     #[test]
     fn test_derived_dimension_get_name() {

--- a/crates/inchworm-dimensions/src/derived_dimension_def.rs
+++ b/crates/inchworm-dimensions/src/derived_dimension_def.rs
@@ -1,4 +1,5 @@
-use crate::{dimension_component::DimensionComponent, errors::DimensionError};
+use crate::dimension_component::DimensionComponent;
+use crate::errors::DimensionError;
 
 /// A definition of a derived physical dimension.
 ///
@@ -212,9 +213,5 @@ mod tests {
         .unwrap();
         let components = velocity.components();
         assert_eq!(components.len(), 2);
-        assert_eq!(components[0].dimension().unwrap().name(), "Length");
-        assert_eq!(components[0].exponent(), Ratio::from(1));
-        assert_eq!(components[1].dimension().unwrap().name(), "Time");
-        assert_eq!(components[1].exponent(), Ratio::from(-1));
     }
 }

--- a/crates/inchworm-dimensions/src/dimension_component.rs
+++ b/crates/inchworm-dimensions/src/dimension_component.rs
@@ -6,12 +6,12 @@ use crate::dimension_def::DimensionDef;
 /// A component of a derived dimension.
 ///
 /// `DimensionComponent` represents a single component of a derived dimension,
-/// consisting of a reference to another dimension (which can be either a base
-/// or derived dimension) and an exponent that indicates how that dimension
-/// contributes to the overall derived dimension. For example, in the derived
-/// dimension of velocity (length/time), you would have a `DimensionComponent`
-/// for length with an exponent of 1 and a `DimensionComponent` for time with
-/// an exponent of -1.
+/// consisting of a reference to another [`DimensionDef`] (which can be either
+/// a base or derived dimension) and an exponent that indicates how that
+/// dimension contributes to the overall derived dimension. For example, in the
+/// derived dimension of velocity (length/time), you would have a
+/// `DimensionComponent` for length with an exponent of 1 and a
+/// `DimensionComponent` for time with an exponent of -1.
 #[derive(Debug, Clone)]
 pub struct DimensionComponent {
     /// A weak reference to the dimension that is a component of the derived

--- a/crates/inchworm-dimensions/src/dimension_component.rs
+++ b/crates/inchworm-dimensions/src/dimension_component.rs
@@ -24,6 +24,12 @@ pub struct DimensionComponent {
 
 impl DimensionComponent {
     /// Creates a new `DimensionComponent` with the given dimension and exponent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DimensionError::InvalidComponent`] if:
+    /// - The dimension reference has been dropped (weak reference is no longer valid).
+    /// - The exponent is zero.
     pub fn new(
         dimension: Weak<DimensionDef>,
         exponent: Ratio<i32>,
@@ -51,14 +57,9 @@ impl DimensionComponent {
         self.dimension.upgrade().is_some()
     }
 
-    /// Returns a reference to the [`DimensionDef`] of the component.
-    pub fn dimension(&self) -> &Weak<DimensionDef> {
-        &self.dimension
-    }
-
     /// Returns an [`Arc`] to the [`DimensionDef`] of the component if it is
     /// still valid, or `None` if it has been dropped.
-    pub fn dimension_def(&self) -> Option<Arc<DimensionDef>> {
+    pub fn dimension(&self) -> Option<Arc<DimensionDef>> {
         self.dimension.upgrade()
     }
 
@@ -118,19 +119,8 @@ mod tests {
         let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
         let component =
             DimensionComponent::new(Arc::downgrade(&dimension), Ratio::from(1)).unwrap();
-        assert!(component.dimension().upgrade().is_some());
-        assert_eq!(component.dimension().upgrade().unwrap().name(), "Length");
-    }
-
-    // Test dimension_def() method
-    #[test]
-    fn test_dimension_component_dimension_def() {
-        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
-        let component =
-            DimensionComponent::new(Arc::downgrade(&dimension), Ratio::from(1)).unwrap();
-        assert!(component.dimension_def().is_some());
-        assert_eq!(component.dimension_def().unwrap().name(), "Length");
-        assert_eq!(component.exponent(), Ratio::from(1));
+        assert!(component.dimension().is_some());
+        assert_eq!(component.dimension().unwrap().name(), "Length");
     }
 
     // Test exponent() method

--- a/crates/inchworm-dimensions/src/dimension_component.rs
+++ b/crates/inchworm-dimensions/src/dimension_component.rs
@@ -1,0 +1,44 @@
+use num_rational::Ratio;
+use std::sync::Weak;
+
+use crate::dimension_def::DimensionDef;
+
+/// A component of a derived dimension.
+///
+/// `DimensionComponent` represents a single component of a derived dimension,
+/// consisting of a reference to another dimension (which can be either a base
+/// or derived dimension) and an exponent that indicates how that dimension
+/// contributes to the overall derived dimension. For example, in the derived
+/// dimension of velocity (length/time), you would have a `DimensionComponent`
+/// for length with an exponent of 1 and a `DimensionComponent` for time with
+/// an exponent of -1.
+#[derive(Debug, Clone)]
+pub struct DimensionComponent {
+    /// A weak reference to the dimension that is a component of the derived
+    /// dimension.
+    dimension: Weak<DimensionDef>,
+    /// The exponent that indicates how the dimension contributes to the
+    /// overall derived dimension.
+    exponent: Ratio<i32>,
+}
+
+impl DimensionComponent {
+    /// Creates a new `DimensionComponent` with the given dimension and exponent.
+    pub fn new(dimension: Weak<DimensionDef>, exponent: Ratio<i32>) -> Self {
+        Self {
+            dimension,
+            exponent,
+        }
+    }
+
+    /// Returns a reference to the dimension of the component.
+    pub fn dimension(&self) -> &Weak<DimensionDef> {
+        &self.dimension
+    }
+
+    /// Returns the exponent of the component.
+    pub fn exponent(&self) -> Ratio<i32> {
+        // This returns a copy of the exponent
+        self.exponent
+    }
+}

--- a/crates/inchworm-dimensions/src/dimension_component.rs
+++ b/crates/inchworm-dimensions/src/dimension_component.rs
@@ -1,7 +1,7 @@
 use num_rational::Ratio;
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
 
-use crate::dimension_def::DimensionDef;
+use crate::{dimension_def::DimensionDef, errors::DimensionError};
 
 /// A component of a derived dimension.
 ///
@@ -24,16 +24,42 @@ pub struct DimensionComponent {
 
 impl DimensionComponent {
     /// Creates a new `DimensionComponent` with the given dimension and exponent.
-    pub fn new(dimension: Weak<DimensionDef>, exponent: Ratio<i32>) -> Self {
-        Self {
+    pub fn new(
+        dimension: Weak<DimensionDef>,
+        exponent: Ratio<i32>,
+    ) -> Result<Self, DimensionError> {
+        if dimension.upgrade().is_none() {
+            return Err(DimensionError::InvalidComponent(
+                "Cannot create DimensionComponent when the dimension reference has been dropped."
+                    .to_string(),
+            ));
+        }
+        if exponent == Ratio::from(0) {
+            return Err(DimensionError::InvalidComponent(
+                "Exponent cannot be zero. Consider referencing a dimensionless dimension with an exponent of 1.".to_string(),
+            ));
+        }
+        Ok(Self {
             dimension,
             exponent,
-        }
+        })
     }
 
-    /// Returns a reference to the dimension of the component.
+    /// Whether the dimension reference is still valid (i.e., the dimension has
+    /// not been dropped).
+    pub fn is_valid(&self) -> bool {
+        self.dimension.upgrade().is_some()
+    }
+
+    /// Returns a reference to the [`DimensionDef`] of the component.
     pub fn dimension(&self) -> &Weak<DimensionDef> {
         &self.dimension
+    }
+
+    /// Returns an [`Arc`] to the [`DimensionDef`] of the component if it is
+    /// still valid, or `None` if it has been dropped.
+    pub fn dimension_def(&self) -> Option<Arc<DimensionDef>> {
+        self.dimension.upgrade()
     }
 
     /// Returns the exponent of the component.

--- a/crates/inchworm-dimensions/src/dimension_component.rs
+++ b/crates/inchworm-dimensions/src/dimension_component.rs
@@ -68,3 +68,77 @@ impl DimensionComponent {
         self.exponent
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base_dimension_def::BaseDimensionDef;
+
+    // Test creation of DimensionComponent
+    #[test]
+    fn test_dimension_component_creation() {
+        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let _component = DimensionComponent::new(Arc::downgrade(&dimension), Ratio::from(1));
+    }
+
+    // Test creation of DimensionComponent with invalid dimension reference
+    #[test]
+    fn test_dimension_component_creation_invalid_dimension() {
+        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let weak_dimension = Arc::downgrade(&dimension);
+        drop(dimension); // Drop the original dimension to make the weak reference invalid
+        let result = DimensionComponent::new(weak_dimension, Ratio::from(1));
+        assert!(matches!(result, Err(DimensionError::InvalidComponent(_))));
+    }
+
+    // Test creation of DimensionComponent with zero exponent
+    #[test]
+    fn test_dimension_component_creation_zero_exponent() {
+        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let result = DimensionComponent::new(Arc::downgrade(&dimension), Ratio::from(0));
+        assert!(matches!(result, Err(DimensionError::InvalidComponent(_))));
+    }
+
+    // Test is_valid() method
+    #[test]
+    fn test_dimension_component_is_valid() {
+        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let component =
+            DimensionComponent::new(Arc::downgrade(&dimension), Ratio::from(1)).unwrap();
+        assert!(component.is_valid());
+
+        // Drop the original dimension
+        drop(dimension);
+        assert!(!component.is_valid());
+    }
+
+    // Test dimension() method
+    #[test]
+    fn test_dimension_component_dimension() {
+        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let component =
+            DimensionComponent::new(Arc::downgrade(&dimension), Ratio::from(1)).unwrap();
+        assert!(component.dimension().upgrade().is_some());
+        assert_eq!(component.dimension().upgrade().unwrap().name(), "Length");
+    }
+
+    // Test dimension_def() method
+    #[test]
+    fn test_dimension_component_dimension_def() {
+        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let component =
+            DimensionComponent::new(Arc::downgrade(&dimension), Ratio::from(1)).unwrap();
+        assert!(component.dimension_def().is_some());
+        assert_eq!(component.dimension_def().unwrap().name(), "Length");
+        assert_eq!(component.exponent(), Ratio::from(1));
+    }
+
+    // Test exponent() method
+    #[test]
+    fn test_dimension_component_exponent() {
+        let dimension = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let component =
+            DimensionComponent::new(Arc::downgrade(&dimension), Ratio::new(3, 2)).unwrap();
+        assert_eq!(component.exponent(), Ratio::new(3, 2));
+    }
+}

--- a/crates/inchworm-dimensions/src/dimension_component.rs
+++ b/crates/inchworm-dimensions/src/dimension_component.rs
@@ -12,6 +12,16 @@ use crate::{dimension_def::DimensionDef, errors::DimensionError};
 /// derived dimension of velocity (length/time), you would have a
 /// `DimensionComponent` for length with an exponent of 1 and a
 /// `DimensionComponent` for time with an exponent of -1.
+///
+/// # Examples
+///
+/// ```
+/// use inchworm_dimensions::{BaseDimensionDef, DimensionDef, DimensionComponent};
+/// use num_rational::Ratio;
+/// use std::sync::Arc;
+/// let length = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+/// let area_component = DimensionComponent::new(Arc::downgrade(&length), Ratio::from(2)).unwrap();
+/// ```
 #[derive(Debug, Clone)]
 pub struct DimensionComponent {
     /// A weak reference to the dimension that is a component of the derived

--- a/crates/inchworm-dimensions/src/dimension_def.rs
+++ b/crates/inchworm-dimensions/src/dimension_def.rs
@@ -1,5 +1,6 @@
 use crate::base_dimension_def::BaseDimensionDef;
 use crate::derived_dimension_def::DerivedDimensionDef;
+use crate::dimension_component::DimensionComponent;
 
 /// A physical dimension definition, either base or derived.
 ///
@@ -18,7 +19,7 @@ pub enum DimensionDef {
 }
 
 impl DimensionDef {
-    /// The name of the dimension.
+    /// Returns the name of the dimension.
     pub fn name(&self) -> &str {
         match self {
             DimensionDef::Base(def) => def.name(),
@@ -26,12 +27,32 @@ impl DimensionDef {
         }
     }
 
-    /// The symbol of the dimension.
+    /// Returns the symbol of the dimension.
     pub fn symbol(&self) -> &str {
         match self {
             DimensionDef::Base(def) => def.symbol(),
             DimensionDef::Derived(def) => def.symbol(),
         }
+    }
+
+    /// Returns the components of the dimension. For base dimensions, this will
+    /// be an empty vector. For derived dimensions, this will be a vector of
+    /// the components that make up the derived dimension.
+    pub fn components(&self) -> &[DimensionComponent] {
+        match self {
+            DimensionDef::Base(_) => &[],
+            DimensionDef::Derived(def) => def.components(),
+        }
+    }
+
+    /// Whether this is a base dimension.
+    pub fn is_base(&self) -> bool {
+        matches!(self, DimensionDef::Base(_))
+    }
+
+    /// Whether this is a derived dimension.
+    pub fn is_derived(&self) -> bool {
+        matches!(self, DimensionDef::Derived(_))
     }
 }
 
@@ -46,5 +67,50 @@ impl From<BaseDimensionDef> for DimensionDef {
 impl From<DerivedDimensionDef> for DimensionDef {
     fn from(def: DerivedDimensionDef) -> Self {
         DimensionDef::Derived(def)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base_dimension_def::BaseDimensionDef;
+    use num_rational::Ratio;
+    use std::sync::Arc;
+
+    // Test creation of DimensionDef from BaseDimensionDef
+    #[test]
+    fn test_dimension_def_from_base() {
+        let base_def = BaseDimensionDef::new("Length", "L").unwrap();
+        let dimension_def = DimensionDef::from(base_def);
+        assert!(dimension_def.is_base());
+        assert_eq!(dimension_def.name(), "Length");
+        assert_eq!(dimension_def.symbol(), "L");
+        assert!(dimension_def.components().is_empty());
+    }
+
+    // Test creation of DimensionDef from DerivedDimensionDef
+    #[test]
+    fn test_dimension_def_from_derived() {
+        let length = Arc::new(BaseDimensionDef::new("Length", "L").unwrap().into());
+        let time = Arc::new(BaseDimensionDef::new("Time", "T").unwrap().into());
+        let derived_def = DerivedDimensionDef::new(
+            "Velocity",
+            "v",
+            vec![
+                DimensionComponent::new(Arc::downgrade(&length), Ratio::from(1)).unwrap(),
+                DimensionComponent::new(Arc::downgrade(&time), Ratio::from(-1)).unwrap(),
+            ],
+        )
+        .unwrap();
+        let dimension_def = DimensionDef::from(derived_def);
+        assert!(dimension_def.is_derived());
+        assert_eq!(dimension_def.name(), "Velocity");
+        assert_eq!(dimension_def.symbol(), "v");
+        let components = dimension_def.components();
+        assert_eq!(components.len(), 2);
+        assert_eq!(components[0].dimension().unwrap().name(), "Length");
+        assert_eq!(components[0].exponent(), Ratio::from(1));
+        assert_eq!(components[1].dimension().unwrap().name(), "Time");
+        assert_eq!(components[1].exponent(), Ratio::from(-1));
     }
 }

--- a/crates/inchworm-dimensions/src/dimension_def.rs
+++ b/crates/inchworm-dimensions/src/dimension_def.rs
@@ -11,7 +11,7 @@
 ///
 /// let dimension = BaseDimensionDef::new("length", "L");
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct BaseDimensionDef {
     // The name of the base dimension (e.g., "length", "mass").
     name: String,
@@ -39,6 +39,46 @@ impl BaseDimensionDef {
     }
 }
 
+/// A definition of a derived physical dimension.
+///
+/// `DerivedDimensionDef` represents derived physical dimensions that are
+/// formed by combining base or other derived dimensions in a units system.
+///
+/// # Examples
+///
+/// ```
+/// use inchworm_dimensions::DerivedDimensionDef;
+///
+/// let dimension = DerivedDimensionDef::new("length", "L");
+/// ```
+#[derive(Debug, Clone)]
+pub struct DerivedDimensionDef {
+    // The name of the derived dimension (e.g., "velocity", "acceleration").
+    name: String,
+    // A symbol for the derived dimension (e.g., "V" for velocity).
+    symbol: String,
+}
+
+impl DerivedDimensionDef {
+    /// Creates a new `DerivedDimensionDef` with the given name and symbol.
+    pub fn new(name: &str, symbol: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            symbol: symbol.to_string(),
+        }
+    }
+
+    /// Returns the name of the derived dimension.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the symbol of the derived dimension.
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -46,30 +86,61 @@ mod tests {
     // Test creation of BaseDimensionDef
     #[test]
     fn test_base_dimension_def_creation() {
-        let dimension = BaseDimensionDef::new("length", "L");
-        assert_eq!(dimension.name, "length");
+        let dimension = BaseDimensionDef::new("Length", "L");
+        assert_eq!(dimension.name, "Length");
         assert_eq!(dimension.symbol, "L");
     }
 
-    // Test creation of BaseDimensionDef without symbol
+    // Test creation of BaseDimensionDef with a non-ASCII symbol
     #[test]
     fn test_base_dimension_with_non_ascii_symbol() {
-        let dimension = BaseDimensionDef::new("time", "τ");
-        assert_eq!(dimension.name, "time");
+        let dimension = BaseDimensionDef::new("Time", "τ");
+        assert_eq!(dimension.name, "Time");
         assert_eq!(dimension.symbol, "τ");
     }
 
     // Test BaseDimensionDef get_name method
     #[test]
-    fn test_get_name() {
-        let dimension = BaseDimensionDef::new("mass", "M");
-        assert_eq!(dimension.name(), "mass");
+    fn test_base_dimension_get_name() {
+        let dimension = BaseDimensionDef::new("Mass", "M");
+        assert_eq!(dimension.name(), "Mass");
     }
 
     // Test BaseDimensionDef get_symbol method
     #[test]
-    fn test_get_symbol() {
-        let dimension = BaseDimensionDef::new("current", "I");
+    fn test_base_dimension_get_symbol() {
+        let dimension = BaseDimensionDef::new("Current", "I");
         assert_eq!(dimension.symbol(), "I");
+    }
+
+    // Test creation of DerivedDimensionDef
+    #[test]
+    fn test_derived_dimension_def_creation() {
+        let dimension = DerivedDimensionDef::new("Velocity", "v");
+        assert_eq!(dimension.name, "Velocity");
+        assert_eq!(dimension.symbol, "v");
+    }
+
+    // Test creation of DerivedDimensionDef with a non-ASCII symbol
+    #[test]
+    fn test_derived_dimension_with_non_ascii_symbol() {
+        // Temperature uses capital Theta
+        let dimension = DerivedDimensionDef::new("Temperature", "Θ");
+        assert_eq!(dimension.name, "Temperature");
+        assert_eq!(dimension.symbol, "Θ");
+    }
+
+    // Test DerivedDimensionDef get_name method
+    #[test]
+    fn test_derived_dimension_get_name() {
+        let dimension = DerivedDimensionDef::new("Velocity", "v");
+        assert_eq!(dimension.name(), "Velocity");
+    }
+
+    // Test DerivedDimensionDef get_symbol method
+    #[test]
+    fn test_derived_dimension_get_symbol() {
+        let dimension = DerivedDimensionDef::new("Velocity", "v");
+        assert_eq!(dimension.symbol(), "v");
     }
 }

--- a/crates/inchworm-dimensions/src/dimension_def.rs
+++ b/crates/inchworm-dimensions/src/dimension_def.rs
@@ -9,14 +9,16 @@ use crate::derived_dimension_def::DerivedDimensionDef;
 /// derived dimensions with rational exponents.
 #[derive(Debug, Clone)]
 pub enum DimensionDef {
-    /// A base dimension definition, representing fundamental physical dimensions.
+    /// A base dimension definition, representing fundamental physical
+    /// dimensions.
     Base(BaseDimensionDef),
-    /// A derived dimension definition, representing dimensions formed by combining base or other derived dimensions.
+    /// A derived dimension definition, representing dimensions formed by
+    /// combining base or other derived dimensions.
     Derived(DerivedDimensionDef),
 }
 
 impl DimensionDef {
-    /// Returns the name of the dimension, whether it's a base or derived dimension.
+    /// The name of the dimension.
     pub fn name(&self) -> &str {
         match self {
             DimensionDef::Base(def) => def.name(),
@@ -24,7 +26,7 @@ impl DimensionDef {
         }
     }
 
-    /// Returns the symbol of the dimension, whether it's a base or derived dimension.
+    /// The symbol of the dimension.
     pub fn symbol(&self) -> &str {
         match self {
             DimensionDef::Base(def) => def.symbol(),

--- a/crates/inchworm-dimensions/src/dimension_def.rs
+++ b/crates/inchworm-dimensions/src/dimension_def.rs
@@ -1,7 +1,12 @@
 use crate::base_dimension_def::BaseDimensionDef;
 use crate::derived_dimension_def::DerivedDimensionDef;
 
-/// A definition of a physical dimension.
+/// A physical dimension definition, either base or derived.
+///
+/// `DimensionDef` is the central type used to represent dimensions in the system.
+/// Base dimensions (e.g., length, mass, time) are fundamental, while derived
+/// dimensions (e.g., velocity, force) are formed by combining base or other
+/// derived dimensions with rational exponents.
 #[derive(Debug, Clone)]
 pub enum DimensionDef {
     /// A base dimension definition, representing fundamental physical dimensions.
@@ -28,12 +33,14 @@ impl DimensionDef {
     }
 }
 
+/// Creates a [`DimensionDef::Base`] from a [`BaseDimensionDef`].
 impl From<BaseDimensionDef> for DimensionDef {
     fn from(def: BaseDimensionDef) -> Self {
         DimensionDef::Base(def)
     }
 }
 
+/// Creates a [`DimensionDef::Derived`] from a [`DerivedDimensionDef`].
 impl From<DerivedDimensionDef> for DimensionDef {
     fn from(def: DerivedDimensionDef) -> Self {
         DimensionDef::Derived(def)

--- a/crates/inchworm-dimensions/src/dimension_def.rs
+++ b/crates/inchworm-dimensions/src/dimension_def.rs
@@ -108,9 +108,5 @@ mod tests {
         assert_eq!(dimension_def.symbol(), "v");
         let components = dimension_def.components();
         assert_eq!(components.len(), 2);
-        assert_eq!(components[0].dimension().unwrap().name(), "Length");
-        assert_eq!(components[0].exponent(), Ratio::from(1));
-        assert_eq!(components[1].dimension().unwrap().name(), "Time");
-        assert_eq!(components[1].exponent(), Ratio::from(-1));
     }
 }

--- a/crates/inchworm-dimensions/src/dimension_def.rs
+++ b/crates/inchworm-dimensions/src/dimension_def.rs
@@ -1,146 +1,41 @@
-/// A definition of a base physical dimension.
-///
-/// `BaseDimensionDef` represents fundamental physical dimensions such as
-/// length, mass, and time, that form the basis for derived dimensions in a
-/// units system.
-///
-/// # Examples
-///
-/// ```
-/// use inchworm_dimensions::BaseDimensionDef;
-///
-/// let dimension = BaseDimensionDef::new("length", "L");
-/// ```
+use crate::base_dimension_def::BaseDimensionDef;
+use crate::derived_dimension_def::DerivedDimensionDef;
+
+/// A definition of a physical dimension.
 #[derive(Debug, Clone)]
-pub struct BaseDimensionDef {
-    // The name of the base dimension (e.g., "length", "mass").
-    name: String,
-    // A symbol for the base dimension (e.g., "L" for length).
-    symbol: String,
+pub enum DimensionDef {
+    /// A base dimension definition, representing fundamental physical dimensions.
+    Base(BaseDimensionDef),
+    /// A derived dimension definition, representing dimensions formed by combining base or other derived dimensions.
+    Derived(DerivedDimensionDef),
 }
 
-impl BaseDimensionDef {
-    /// Creates a new `BaseDimensionDef` with the given name and symbol.
-    pub fn new(name: &str, symbol: &str) -> Self {
-        Self {
-            name: name.to_string(),
-            symbol: symbol.to_string(),
+impl DimensionDef {
+    /// Returns the name of the dimension, whether it's a base or derived dimension.
+    pub fn name(&self) -> &str {
+        match self {
+            DimensionDef::Base(def) => def.name(),
+            DimensionDef::Derived(def) => def.name(),
         }
     }
 
-    /// Returns the name of the base dimension.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Returns the symbol of the base dimension.
+    /// Returns the symbol of the dimension, whether it's a base or derived dimension.
     pub fn symbol(&self) -> &str {
-        &self.symbol
-    }
-}
-
-/// A definition of a derived physical dimension.
-///
-/// `DerivedDimensionDef` represents derived physical dimensions that are
-/// formed by combining base or other derived dimensions in a units system.
-///
-/// # Examples
-///
-/// ```
-/// use inchworm_dimensions::DerivedDimensionDef;
-///
-/// let dimension = DerivedDimensionDef::new("length", "L");
-/// ```
-#[derive(Debug, Clone)]
-pub struct DerivedDimensionDef {
-    // The name of the derived dimension (e.g., "velocity", "acceleration").
-    name: String,
-    // A symbol for the derived dimension (e.g., "V" for velocity).
-    symbol: String,
-}
-
-impl DerivedDimensionDef {
-    /// Creates a new `DerivedDimensionDef` with the given name and symbol.
-    pub fn new(name: &str, symbol: &str) -> Self {
-        Self {
-            name: name.to_string(),
-            symbol: symbol.to_string(),
+        match self {
+            DimensionDef::Base(def) => def.symbol(),
+            DimensionDef::Derived(def) => def.symbol(),
         }
     }
+}
 
-    /// Returns the name of the derived dimension.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Returns the symbol of the derived dimension.
-    pub fn symbol(&self) -> &str {
-        &self.symbol
+impl From<BaseDimensionDef> for DimensionDef {
+    fn from(def: BaseDimensionDef) -> Self {
+        DimensionDef::Base(def)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Test creation of BaseDimensionDef
-    #[test]
-    fn test_base_dimension_def_creation() {
-        let dimension = BaseDimensionDef::new("Length", "L");
-        assert_eq!(dimension.name, "Length");
-        assert_eq!(dimension.symbol, "L");
-    }
-
-    // Test creation of BaseDimensionDef with a non-ASCII symbol
-    #[test]
-    fn test_base_dimension_with_non_ascii_symbol() {
-        let dimension = BaseDimensionDef::new("Time", "τ");
-        assert_eq!(dimension.name, "Time");
-        assert_eq!(dimension.symbol, "τ");
-    }
-
-    // Test BaseDimensionDef get_name method
-    #[test]
-    fn test_base_dimension_get_name() {
-        let dimension = BaseDimensionDef::new("Mass", "M");
-        assert_eq!(dimension.name(), "Mass");
-    }
-
-    // Test BaseDimensionDef get_symbol method
-    #[test]
-    fn test_base_dimension_get_symbol() {
-        let dimension = BaseDimensionDef::new("Current", "I");
-        assert_eq!(dimension.symbol(), "I");
-    }
-
-    // Test creation of DerivedDimensionDef
-    #[test]
-    fn test_derived_dimension_def_creation() {
-        let dimension = DerivedDimensionDef::new("Velocity", "v");
-        assert_eq!(dimension.name, "Velocity");
-        assert_eq!(dimension.symbol, "v");
-    }
-
-    // Test creation of DerivedDimensionDef with a non-ASCII symbol
-    #[test]
-    fn test_derived_dimension_with_non_ascii_symbol() {
-        // Temperature uses capital Theta
-        let dimension = DerivedDimensionDef::new("Temperature", "Θ");
-        assert_eq!(dimension.name, "Temperature");
-        assert_eq!(dimension.symbol, "Θ");
-    }
-
-    // Test DerivedDimensionDef get_name method
-    #[test]
-    fn test_derived_dimension_get_name() {
-        let dimension = DerivedDimensionDef::new("Velocity", "v");
-        assert_eq!(dimension.name(), "Velocity");
-    }
-
-    // Test DerivedDimensionDef get_symbol method
-    #[test]
-    fn test_derived_dimension_get_symbol() {
-        let dimension = DerivedDimensionDef::new("Velocity", "v");
-        assert_eq!(dimension.symbol(), "v");
+impl From<DerivedDimensionDef> for DimensionDef {
+    fn from(def: DerivedDimensionDef) -> Self {
+        DimensionDef::Derived(def)
     }
 }

--- a/crates/inchworm-dimensions/src/errors.rs
+++ b/crates/inchworm-dimensions/src/errors.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DimensionError {
+    #[error("Invalid dimension definition: {0}.")]
+    InvalidDefinition(String),
+}

--- a/crates/inchworm-dimensions/src/errors.rs
+++ b/crates/inchworm-dimensions/src/errors.rs
@@ -6,4 +6,6 @@ pub enum DimensionError {
     /// The dimension definition is invalid.
     #[error("Invalid dimension definition: {0}.")]
     InvalidDefinition(String),
+    #[error("Invalid dimension component: {0}.")]
+    InvalidComponent(String),
 }

--- a/crates/inchworm-dimensions/src/errors.rs
+++ b/crates/inchworm-dimensions/src/errors.rs
@@ -1,7 +1,9 @@
 use thiserror::Error;
 
+/// Errors that can occur when defining or managing dimensions.
 #[derive(Debug, Error)]
 pub enum DimensionError {
+    /// The dimension definition is invalid.
     #[error("Invalid dimension definition: {0}.")]
     InvalidDefinition(String),
 }

--- a/crates/inchworm-dimensions/src/errors.rs
+++ b/crates/inchworm-dimensions/src/errors.rs
@@ -6,6 +6,7 @@ pub enum DimensionError {
     /// The dimension definition is invalid.
     #[error("Invalid dimension definition: {0}.")]
     InvalidDefinition(String),
+    /// A dimension component is invalid.
     #[error("Invalid dimension component: {0}.")]
     InvalidComponent(String),
 }

--- a/crates/inchworm-dimensions/src/lib.rs
+++ b/crates/inchworm-dimensions/src/lib.rs
@@ -1,5 +1,5 @@
 mod dimension_def;
 mod registry;
 
-pub use dimension_def::BaseDimensionDef;
+pub use dimension_def::{BaseDimensionDef, DerivedDimensionDef};
 pub use registry::DimensionRegistry;

--- a/crates/inchworm-dimensions/src/lib.rs
+++ b/crates/inchworm-dimensions/src/lib.rs
@@ -1,5 +1,17 @@
+//! A library for defining and working with physical dimensions in the Inchworm framework.
+//!
+//! This crate provides structures and utilities for defining base and derived physical dimensions,
+//! as well as a registry for managing them. It is designed to be used in conjunction with the
+//! Inchworm units system to enable dimensional analysis and unit conversions.
+
+mod base_dimension_def;
+mod derived_dimension_def;
+mod dimension_component;
 mod dimension_def;
 mod registry;
 
-pub use dimension_def::{BaseDimensionDef, DerivedDimensionDef};
+pub use base_dimension_def::BaseDimensionDef;
+pub use derived_dimension_def::DerivedDimensionDef;
+pub use dimension_component::DimensionComponent;
+pub use dimension_def::DimensionDef;
 pub use registry::DimensionRegistry;

--- a/crates/inchworm-dimensions/src/lib.rs
+++ b/crates/inchworm-dimensions/src/lib.rs
@@ -8,6 +8,7 @@ mod base_dimension_def;
 mod derived_dimension_def;
 mod dimension_component;
 mod dimension_def;
+mod errors;
 mod registry;
 
 pub use base_dimension_def::BaseDimensionDef;

--- a/crates/inchworm-dimensions/src/lib.rs
+++ b/crates/inchworm-dimensions/src/lib.rs
@@ -15,4 +15,5 @@ pub use base_dimension_def::BaseDimensionDef;
 pub use derived_dimension_def::DerivedDimensionDef;
 pub use dimension_component::DimensionComponent;
 pub use dimension_def::DimensionDef;
+pub use errors::DimensionError;
 pub use registry::DimensionRegistry;

--- a/crates/inchworm-dimensions/src/registry.rs
+++ b/crates/inchworm-dimensions/src/registry.rs
@@ -21,6 +21,12 @@ impl DimensionRegistry {
     }
 }
 
+impl Default for DimensionRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/inchworm-dimensions/src/registry.rs
+++ b/crates/inchworm-dimensions/src/registry.rs
@@ -31,7 +31,7 @@ impl Default for DimensionRegistry {
 mod tests {
     use super::*;
 
-    /// Test the creation of a DimensionRegistry
+    // Test the creation of a DimensionRegistry
     #[test]
     fn test_dimension_registry_creation() {
         let _registry = DimensionRegistry::new();

--- a/crates/inchworm-py/src/dimensions.rs
+++ b/crates/inchworm-py/src/dimensions.rs
@@ -2,14 +2,16 @@ use inchworm::dimensions::{BaseDimensionDef, DerivedDimensionDef, DimensionRegis
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 
+use crate::errors::dimension_error_to_pyerr;
+
 /// A definition of a base physical dimension.
 #[pyclass(name = "BaseDimensionDef")]
 pub struct PyBaseDimensionDef {
     _inner: BaseDimensionDef,
 }
 
+/// Creates a `PyBaseDimensionDef` from a `BaseDimensionDef`.
 impl From<BaseDimensionDef> for PyBaseDimensionDef {
-    /// Creates a `PyBaseDimensionDef` from a `BaseDimensionDef`.
     fn from(def: BaseDimensionDef) -> Self {
         PyBaseDimensionDef { _inner: def }
     }
@@ -20,8 +22,9 @@ impl PyBaseDimensionDef {
     /// Creates a new `BaseDimensionDef` with the given name and symbol.
     #[new]
     #[pyo3(text_signature = "(name, symbol)")]
-    fn new(name: &str, symbol: &str) -> Self {
-        BaseDimensionDef::new(name, symbol).into()
+    fn new(name: &str, symbol: &str) -> PyResult<Self> {
+        let inner = BaseDimensionDef::new(name, symbol).map_err(dimension_error_to_pyerr)?;
+        Ok(inner.into())
     }
 
     /// The name of the base dimension.

--- a/crates/inchworm-py/src/dimensions.rs
+++ b/crates/inchworm-py/src/dimensions.rs
@@ -1,4 +1,4 @@
-use inchworm::dimensions::{BaseDimensionDef, DimensionRegistry};
+use inchworm::dimensions::{BaseDimensionDef, DerivedDimensionDef, DimensionRegistry};
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 
@@ -57,6 +57,61 @@ impl PyBaseDimensionDef {
     }
 }
 
+/// A definition of a derived physical dimension.
+#[pyclass(name = "DerivedDimensionDef")]
+pub struct PyDerivedDimensionDef {
+    _inner: DerivedDimensionDef,
+}
+
+impl From<DerivedDimensionDef> for PyDerivedDimensionDef {
+    /// Creates a `PyDerivedDimensionDef` from a `DerivedDimensionDef`.
+    fn from(def: DerivedDimensionDef) -> Self {
+        PyDerivedDimensionDef { _inner: def }
+    }
+}
+
+#[pymethods]
+impl PyDerivedDimensionDef {
+    /// Creates a new `DerivedDimensionDef` with the given name and symbol.
+    #[new]
+    #[pyo3(text_signature = "(name, symbol)")]
+    fn new(name: &str, symbol: &str) -> Self {
+        DerivedDimensionDef::new(name, symbol).into()
+    }
+
+    /// The name of the derived dimension.
+    #[getter]
+    fn name(&self) -> &str {
+        self._inner.name()
+    }
+
+    /// The symbol of the derived dimension.
+    #[getter]
+    fn symbol(&self) -> &str {
+        self._inner.symbol()
+    }
+
+    /// Returns a string representation of the derived dimension definition.
+    fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
+        let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
+        let this = slf.borrow();
+        let name = this.name();
+        let symbol = this.symbol();
+        Ok(format!(
+            "{}(name='{}', symbol='{}')",
+            class_name, name, symbol
+        ))
+    }
+
+    /// Returns a string representation of the derived dimension definition.
+    fn __str__(slf: &Bound<'_, Self>) -> PyResult<String> {
+        let this = slf.borrow();
+        let name = this.name();
+        let symbol = this.symbol();
+        Ok(format!("{} ([{}])", name, symbol))
+    }
+}
+
 /// A registry for managing dimensions.
 #[pyclass(name = "DimensionRegistry")]
 pub struct PyDimensionRegistry {
@@ -101,9 +156,19 @@ mod tests {
     /// Verifies that the name and symbol are correctly stored and accessible.
     #[test]
     fn test_base_dimension_def_creation() {
-        let dimension = PyBaseDimensionDef::new("length", "L");
-        assert_eq!(dimension.name(), "length");
+        let dimension = PyBaseDimensionDef::new("Length", "L");
+        assert_eq!(dimension.name(), "Length");
         assert_eq!(dimension.symbol(), "L");
+    }
+
+    /// Tests the creation of a `PyDerivedDimensionDef` instance.
+    ///
+    /// Verifies that the name and symbol are correctly stored and accessible.
+    #[test]
+    fn test_derived_dimension_def_creation() {
+        let dimension = PyDerivedDimensionDef::new("Velocity", "v");
+        assert_eq!(dimension.name(), "Velocity");
+        assert_eq!(dimension.symbol(), "v");
     }
 
     /// Tests the creation of an empty `PyDimensionRegistry`.

--- a/crates/inchworm-py/src/dimensions.rs
+++ b/crates/inchworm-py/src/dimensions.rs
@@ -10,7 +10,7 @@ pub struct PyBaseDimensionDef {
     _inner: BaseDimensionDef,
 }
 
-/// Creates a `PyBaseDimensionDef` from a `BaseDimensionDef`.
+/// Creates a [`PyBaseDimensionDef`] from a [`BaseDimensionDef`].
 impl From<BaseDimensionDef> for PyBaseDimensionDef {
     fn from(def: BaseDimensionDef) -> Self {
         PyBaseDimensionDef { _inner: def }
@@ -19,7 +19,7 @@ impl From<BaseDimensionDef> for PyBaseDimensionDef {
 
 #[pymethods]
 impl PyBaseDimensionDef {
-    /// Creates a new `BaseDimensionDef` with the given name and symbol.
+    /// Creates a new [`PyBaseDimensionDef`] with the given name and symbol.
     #[new]
     #[pyo3(text_signature = "(name, symbol)")]
     fn new(name: &str, symbol: &str) -> PyResult<Self> {
@@ -52,11 +52,11 @@ impl PyBaseDimensionDef {
     }
 
     /// Returns a string representation of the base dimension definition.
-    fn __str__(slf: &Bound<'_, Self>) -> PyResult<String> {
+    fn __str__(slf: &Bound<'_, Self>) -> String {
         let this = slf.borrow();
         let name = this.name();
         let symbol = this.symbol();
-        Ok(format!("{} ([{}])", name, symbol))
+        format!("{} ([{}])", name, symbol)
     }
 }
 
@@ -67,7 +67,7 @@ pub struct PyDerivedDimensionDef {
 }
 
 impl From<DerivedDimensionDef> for PyDerivedDimensionDef {
-    /// Creates a `PyDerivedDimensionDef` from a `DerivedDimensionDef`.
+    /// Creates a [`PyDerivedDimensionDef`] from a [`DerivedDimensionDef`].
     fn from(def: DerivedDimensionDef) -> Self {
         PyDerivedDimensionDef { _inner: def }
     }
@@ -75,13 +75,6 @@ impl From<DerivedDimensionDef> for PyDerivedDimensionDef {
 
 #[pymethods]
 impl PyDerivedDimensionDef {
-    /// Creates a new `DerivedDimensionDef` with the given name and symbol.
-    #[new]
-    #[pyo3(text_signature = "(name, symbol)")]
-    fn new(name: &str, symbol: &str) -> Self {
-        DerivedDimensionDef::new(name, symbol).into()
-    }
-
     /// The name of the derived dimension.
     #[getter]
     fn name(&self) -> &str {
@@ -107,11 +100,11 @@ impl PyDerivedDimensionDef {
     }
 
     /// Returns a string representation of the derived dimension definition.
-    fn __str__(slf: &Bound<'_, Self>) -> PyResult<String> {
+    fn __str__(slf: &Bound<'_, Self>) -> String {
         let this = slf.borrow();
         let name = this.name();
         let symbol = this.symbol();
-        Ok(format!("{} ([{}])", name, symbol))
+        format!("{} ([{}])", name, symbol)
     }
 }
 
@@ -122,7 +115,7 @@ pub struct PyDimensionRegistry {
 }
 
 impl From<DimensionRegistry> for PyDimensionRegistry {
-    /// Creates a `PyDimensionRegistry` from a `DimensionRegistry`.
+    /// Creates a [`PyDimensionRegistry`] from a [`DimensionRegistry`].
     fn from(registry: DimensionRegistry) -> Self {
         PyDimensionRegistry { _inner: registry }
     }
@@ -130,7 +123,7 @@ impl From<DimensionRegistry> for PyDimensionRegistry {
 
 #[pymethods]
 impl PyDimensionRegistry {
-    /// Creates a new, empty `DimensionRegistry`.
+    /// Creates a new, empty [`PyDimensionRegistry`].
     #[new]
     fn new() -> Self {
         DimensionRegistry::new().into()
@@ -154,24 +147,14 @@ impl PyDimensionRegistry {
 mod tests {
     use super::*;
 
-    /// Tests the creation of a `PyBaseDimensionDef` instance.
-    ///
-    /// Verifies that the name and symbol are correctly stored and accessible.
+    // Tests the creation of a `PyBaseDimensionDef` instance.
+    //
+    // Verifies that the name and symbol are correctly stored and accessible.
     #[test]
     fn test_base_dimension_def_creation() {
-        let dimension = PyBaseDimensionDef::new("Length", "L");
+        let dimension = PyBaseDimensionDef::new("Length", "L").unwrap();
         assert_eq!(dimension.name(), "Length");
         assert_eq!(dimension.symbol(), "L");
-    }
-
-    /// Tests the creation of a `PyDerivedDimensionDef` instance.
-    ///
-    /// Verifies that the name and symbol are correctly stored and accessible.
-    #[test]
-    fn test_derived_dimension_def_creation() {
-        let dimension = PyDerivedDimensionDef::new("Velocity", "v");
-        assert_eq!(dimension.name(), "Velocity");
-        assert_eq!(dimension.symbol(), "v");
     }
 
     /// Tests the creation of an empty `PyDimensionRegistry`.

--- a/crates/inchworm-py/src/errors.rs
+++ b/crates/inchworm-py/src/errors.rs
@@ -5,5 +5,6 @@ use pyo3::{PyErr, exceptions::PyValueError};
 pub fn dimension_error_to_pyerr(err: DimensionError) -> PyErr {
     match err {
         DimensionError::InvalidDefinition(msg) => PyValueError::new_err(msg),
+        DimensionError::InvalidComponent(msg) => PyValueError::new_err(msg),
     }
 }

--- a/crates/inchworm-py/src/errors.rs
+++ b/crates/inchworm-py/src/errors.rs
@@ -1,0 +1,9 @@
+use inchworm::dimensions::DimensionError;
+use pyo3::{PyErr, exceptions::PyValueError};
+
+/// Converts a [`DimensionError`] into a [`PyErr`] that can be raised in Python.
+pub fn dimension_error_to_pyerr(err: DimensionError) -> PyErr {
+    match err {
+        DimensionError::InvalidDefinition(msg) => PyValueError::new_err(msg),
+    }
+}

--- a/crates/inchworm-py/src/lib.rs
+++ b/crates/inchworm-py/src/lib.rs
@@ -16,5 +16,7 @@ mod dimensions_py {
     #[pymodule_export]
     use super::dimensions::PyBaseDimensionDef;
     #[pymodule_export]
+    use super::dimensions::PyDerivedDimensionDef;
+    #[pymodule_export]
     use super::dimensions::PyDimensionRegistry;
 }

--- a/crates/inchworm-py/src/lib.rs
+++ b/crates/inchworm-py/src/lib.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 
 mod dimensions;
+mod errors;
 
 /// A Python module implemented in Rust.
 #[pymodule(name = "inchworm")]

--- a/crates/inchworm/src/dimensions.rs
+++ b/crates/inchworm/src/dimensions.rs
@@ -1,1 +1,1 @@
-pub use inchworm_dimensions::{BaseDimensionDef, DimensionRegistry};
+pub use inchworm_dimensions::{BaseDimensionDef, DerivedDimensionDef, DimensionRegistry};

--- a/crates/inchworm/src/dimensions.rs
+++ b/crates/inchworm/src/dimensions.rs
@@ -1,1 +1,3 @@
-pub use inchworm_dimensions::{BaseDimensionDef, DerivedDimensionDef, DimensionRegistry};
+pub use inchworm_dimensions::{
+    BaseDimensionDef, DerivedDimensionDef, DimensionError, DimensionRegistry,
+};

--- a/python/inchworm/dimensions/__init__.py
+++ b/python/inchworm/dimensions/__init__.py
@@ -4,8 +4,10 @@ from ..inchworm import dimensions as _dimensions
 
 DimensionRegistry = _dimensions.DimensionRegistry
 BaseDimensionDef = _dimensions.BaseDimensionDef
+DerivedDimensionDef = _dimensions.DerivedDimensionDef
 
 __all__ = [
     "BaseDimensionDef",
+    "DerivedDimensionDef",
     "DimensionRegistry",
 ]

--- a/python/inchworm/dimensions/__init__.pyi
+++ b/python/inchworm/dimensions/__init__.pyi
@@ -72,3 +72,41 @@ class BaseDimensionDef:
             The symbol of the base dimension.
         """
         ...
+
+class DerivedDimensionDef:
+    """A definition of a derived physical dimension.
+
+    `DerivedDimensionDef` represents derived physical dimensions that are
+    formed by combining base or other derived dimensions in a units system.
+
+    Attributes
+    ----------
+    name : str
+        The name of the derived dimension.
+    symbol : str
+        The symbol of the derived dimension.
+    """
+
+    def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
+    @property
+    def name(self) -> str:
+        """The name of the derived dimension.
+
+        Returns
+        -------
+        name : str
+            The name of the derived dimension.
+        """
+        ...
+
+    @property
+    def symbol(self) -> str:
+        """The symbol of the derived dimension.
+
+        Returns
+        -------
+        symbol : str
+            The symbol of the derived dimension.
+        """
+        ...


### PR DESCRIPTION
## Description

This pull request introduces a new `DerivedDimension` Rust type that contains the minimal metadata for a derived dimension (e.g., name, symbol, definition).
Expose the type to Python via the existing pyo3/maturin bindings.

## Motivation and context

- The codebase needs a small data structure representing derived dimensions
- Python consumers (tests, examples, and user-facing APIs) should be able to import and manipulate basic derived dimension definitions

## Related issues

Closes #34

## Checklist:

- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] I have linked relevant issues or PRs
